### PR TITLE
Fix PyTorch dependency issue and update instructions to include PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,15 @@ Install via the Pinokio community script "FP-Studio" or:
    cd FramePack-Studio
    ```
 
-2. Install dependencies:
+2. Install PyTorch:
+
+   Go to the [PyTorch Getting Started](https://pytorch.org/get-started/locally/) page and install PyTorch according to your system setup.
+   For example, if using CUDA 12.6 on Windows:
+   ```bash
+   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+   ```
+
+3. Install additional dependencies:
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ scipy==1.12.0
 requests==2.31.0
 torchsde==0.2.6
 jinja2>=3.1.2
-torchvision
 einops
 opencv-contrib-python
 safetensors


### PR DESCRIPTION
I noticed the instruction to install PyTorch is completely missing in this repo, and that torchvision has been added to requirements.txt. torchvision probably shouldn't be in requirements.txt and there should be instructions to install PyTorch according to your system setup (i.e. closer to how it was in the original FramePack repo). 

The reason this is a problem is, to install PyTorch you have to install the correct version based on your system config, for example:
Windows + CUDA 12.6: pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
Windows + CPU only: pip3 install torch torchvision torchaudio
Linux + CUDA 12.6: pip3 install torch torchvision torchaudio
Linux + CPU only: pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu

And yes, that's not a typo, under Linux, you don't pass a custom URL for CUDA 12.6, as that is the default pip installation for PyTorch under Linux, but on Windows, this is the install command for the CPU only version. I suspect right now it will be installing the CPU version of PyTorch under Windows if you just follow the setup instructions without explicitly installing the correct version of PyTorch first, since I suspect torchvision will pull torch as a dependency, but of course it'll pull the CPU only version since it won't be going to their custom URL for CUDA under Windows.

This PR removes torchvision from requirements.txt to avoid these issues and adds instructions to the readme.md to install PyTorch properly according to your system setup.