### PR TITLE
Support organising LoRAs in subdirectories

### DIFF
--- a/diffusers_helper/lora_utils.py
+++ b/diffusers_helper/lora_utils.py
@@ -37,7 +37,7 @@ def load_lora(transformer, lora_path: Path, weight_name: Optional[str] = "pytorc
     # For now, we assume it is never None
     # The module name in the state_dict must not include a . in the name
     # See https://github.com/pytorch/pytorch/pull/6639/files#diff-4be56271f7bfe650e3521c81fd363da58f109cd23ee80d243156d2d6ccda6263R133-R134
-    adapter_name = PurePath(str(weight_name).replace('_DOT_', '.')).stem.replace('.', '_DOT_')
+    adapter_name = str(PurePath(weight_name).with_suffix('')).replace('.', '_DOT_')
     if '_DOT_' in adapter_name:
         print(
             f"LoRA file '{weight_name}' contains a '.' in the name. " +

--- a/modules/generators/base_generator.py
+++ b/modules/generators/base_generator.py
@@ -183,21 +183,20 @@ class BaseModelGenerator(ABC):
                 idx = lora_loaded_names.index(lora_name)
                 lora_file = None
                 for ext in [".safetensors", ".pt"]:
-                    # Find any file that starts with the lora_name and ends with the extension
-                    matching_files = [f for f in os.listdir(lora_folder) 
-                                   if f.startswith(lora_name) and f.endswith(ext)]
-                    if matching_files:
-                        lora_file = matching_files[0]  # Use the first matching file
+                    candidate_path_relative = f"{lora_name}{ext}"
+                    candidate_path_full = os.path.join(lora_folder, candidate_path_relative)
+                    if os.path.isfile(candidate_path_full):
+                        lora_file = candidate_path_relative
                         break
                         
                 if lora_file:
-                    print(f"Loading LoRA {lora_file} to {self.get_model_name()} model")
+                    print(f"Loading LoRA '{lora_file}' to {self.get_model_name()} model")
                     self.transformer = lora_utils.load_lora(self.transformer, lora_folder, lora_file)
                     
                     # Set LoRA strength if provided
                     if lora_values and idx < len(lora_values):
                         lora_strength = float(lora_values[idx])
-                        print(f"Setting LoRA {lora_name} strength to {lora_strength}")
+                        print(f"Setting LoRA '{lora_name}' strength to {lora_strength}")
                         
                         # Set scaling for this LoRA by iterating through modules
                         for name, module in self.transformer.named_modules():

--- a/studio.py
+++ b/studio.py
@@ -161,11 +161,12 @@ lora_folder_from_settings: str = settings.get("lora_dir", default_lora_folder) #
 print(f"Scanning for LoRAs in: {lora_folder_from_settings}")
 if os.path.isdir(lora_folder_from_settings):
     try:
-        lora_files = [f for f in os.listdir(lora_folder_from_settings)
-                     if f.endswith('.safetensors') or f.endswith('.pt')]
-        for lora_file in lora_files:
-            lora_name = PurePath(lora_file).stem
-            lora_names.append(lora_name) # Get name without extension
+        for root, _, files in os.walk(lora_folder_from_settings):
+            for file in files:
+                if file.endswith('.safetensors') or file.endswith('.pt'):
+                    lora_relative_path = os.path.relpath(os.path.join(root, file), lora_folder_from_settings)
+                    lora_name = str(PurePath(lora_relative_path).with_suffix(''))
+                    lora_names.append(lora_name)
         print(f"Found LoRAs: {lora_names}")
     except Exception as e:
         print(f"Error scanning LoRA directory '{lora_folder_from_settings}': {e}")


### PR DESCRIPTION
This PR allows you to have your LoRAs in subdirectories under the LoRA folder. This is useful if you have a large collection of LoRAs where it is impractical to put all those LoRAs under a single directory.

I've compared the generations between the develop branch and my own branch and it gives the same results in my tests where I have two LoRAs loaded, the only difference being that with the dev test I had both my LoRAs in the same single lora directory as supported on dev, versus loading those same LoRAs from my existing Hunyuan LoRA folder structure in my branch.

I had to switch away from using stem as that kills the full directory structure and only retains the filename, so I'm using with_suffix('') instead, which just strips off the extension.