### PR TITLE
Add TeaCache sliders to control frame caching behavior

### DIFF
--- a/modules/interface.py
+++ b/modules/interface.py
@@ -184,7 +184,10 @@ def create_interface(
                                 )
                                 save_metadata = gr.Checkbox(label="Save Metadata", value=True, info="Save to JSON file")
                             with gr.Row("TeaCache"):
-                                use_teacache = gr.Checkbox(label='Use TeaCache', value=True, info='Faster speed, but often makes hands and fingers slightly worse.')
+                                use_teacache = gr.Checkbox(label='Use TeaCache', value=False, info='Faster speed, but often makes hands and fingers slightly worse.')
+                                teacache_num_steps = gr.Slider(label="TeaCache steps", minimum=1, maximum=50, step=1, value=25, visible=False, info='Сколько промежуточных секций держать в кэше')
+                                teacache_rel_l1_thresh = gr.Slider(label="TeaCache rel_l1_thresh", minimum=0.01, maximum=1.0, step=0.01, value=0.15, visible=False, info='Порог L1-расхождения')
+                                use_teacache.change(lambda enabled: (gr.update(visible=enabled), gr.update(visible=enabled)), inputs=use_teacache, outputs=[teacache_num_steps, teacache_rel_l1_thresh])
                                 n_prompt = gr.Textbox(label="Negative Prompt", value="", visible=False)  # Not used
 
                             with gr.Row():
@@ -284,7 +287,10 @@ def create_interface(
                                 )
                                 f1_save_metadata = gr.Checkbox(label="Save Metadata", value=True, info="Save to JSON file")
                             with gr.Row("TeaCache"):
-                                f1_use_teacache = gr.Checkbox(label='Use TeaCache', value=True, info='Faster speed, but often makes hands and fingers slightly worse.')
+                                f1_use_teacache = gr.Checkbox(label='Use TeaCache', value=False, info='Faster speed, but often makes hands and fingers slightly worse.')
+                                f1_teacache_num_steps = gr.Slider(label="TeaCache num_steps", minimum=1, maximum=50, step=1, value=25, visible=False, info='Количество промежуточных шагов для кэша')
+                                f1_teacache_rel_l1_thresh = gr.Slider(label="TeaCache rel_l1_thresh", minimum=0.01, maximum=1.0, step=0.01, value=0.15, visible=False, info='Порог L1-расхождения')
+                                f1_use_teacache.change(lambda enabled: (gr.update(visible=enabled), gr.update(visible=enabled)), inputs=f1_use_teacache, outputs=[f1_teacache_num_steps, f1_teacache_rel_l1_thresh])
                                 f1_n_prompt = gr.Textbox(label="Negative Prompt", value="", visible=True)
 
                             with gr.Row():
@@ -512,7 +518,7 @@ def create_interface(
         # Connect the main process function (wrapper for adding to queue)
         def process_with_queue_update(model_type, *args):
             # Extract all arguments (ensure order matches inputs lists)
-            input_image, prompt_text, n_prompt, seed_value, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf, randomize_seed_checked, save_metadata_checked, blend_sections, latent_type, clean_up_videos, selected_loras, resolutionW, resolutionH, *lora_args = args
+            input_image, prompt_text, n_prompt, seed_value, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, teacache_num_steps, teacache_rel_l1_thresh, mp4_crf, randomize_seed_checked, save_metadata_checked, blend_sections, latent_type, clean_up_videos, selected_loras, resolutionW, resolutionH, *lora_args = args
 
             # DO NOT parse the prompt here. Parsing happens once in the worker.
 
@@ -521,7 +527,7 @@ def create_interface(
             # Pass the model_type and the ORIGINAL prompt_text string to the backend process function
             result = process_fn(model_type, input_image, prompt_text, n_prompt, seed_value, total_second_length, # Pass original prompt_text string
                             latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation,
-                            use_teacache, mp4_crf, save_metadata_checked, blend_sections, latent_type, clean_up_videos, selected_loras, resolutionW, resolutionH, *lora_args)
+                            use_teacache, teacache_num_steps, teacache_rel_l1_thresh, mp4_crf, save_metadata_checked, blend_sections, latent_type, clean_up_videos, selected_loras, resolutionW, resolutionH, *lora_args)
 
             # If randomize_seed is checked, generate a new random seed for the next job
             new_seed_value = None
@@ -567,6 +573,8 @@ def create_interface(
             rs,
             gpu_memory_preservation,
             use_teacache,
+            teacache_num_steps,
+            teacache_rel_l1_thresh,
             mp4_crf,
             randomize_seed,
             save_metadata,
@@ -595,6 +603,8 @@ def create_interface(
             f1_rs,
             f1_gpu_memory_preservation,
             f1_use_teacache,
+            f1_teacache_num_steps,
+            f1_teacache_rel_l1_thresh,
             f1_mp4_crf,
             f1_randomize_seed,
             f1_save_metadata,

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -185,8 +185,8 @@ def create_interface(
                                 save_metadata = gr.Checkbox(label="Save Metadata", value=True, info="Save to JSON file")
                             with gr.Row("TeaCache"):
                                 use_teacache = gr.Checkbox(label='Use TeaCache', value=False, info='Faster speed, but often makes hands and fingers slightly worse.')
-                                teacache_num_steps = gr.Slider(label="TeaCache steps", minimum=1, maximum=50, step=1, value=25, visible=False, info='Сколько промежуточных секций держать в кэше')
-                                teacache_rel_l1_thresh = gr.Slider(label="TeaCache rel_l1_thresh", minimum=0.01, maximum=1.0, step=0.01, value=0.15, visible=False, info='Порог L1-расхождения')
+                                teacache_num_steps = gr.Slider(label="TeaCache steps", minimum=1, maximum=50, step=1, value=25, visible=False, info='Number of intermediate steps for the cache')
+                                teacache_rel_l1_thresh = gr.Slider(label="TeaCache rel_l1_thresh", minimum=0.01, maximum=1.0, step=0.01, value=0.15, visible=False, info='Relative L1 divergence threshold')
                                 use_teacache.change(lambda enabled: (gr.update(visible=enabled), gr.update(visible=enabled)), inputs=use_teacache, outputs=[teacache_num_steps, teacache_rel_l1_thresh])
                                 n_prompt = gr.Textbox(label="Negative Prompt", value="", visible=False)  # Not used
 
@@ -288,8 +288,8 @@ def create_interface(
                                 f1_save_metadata = gr.Checkbox(label="Save Metadata", value=True, info="Save to JSON file")
                             with gr.Row("TeaCache"):
                                 f1_use_teacache = gr.Checkbox(label='Use TeaCache', value=False, info='Faster speed, but often makes hands and fingers slightly worse.')
-                                f1_teacache_num_steps = gr.Slider(label="TeaCache num_steps", minimum=1, maximum=50, step=1, value=25, visible=False, info='Количество промежуточных шагов для кэша')
-                                f1_teacache_rel_l1_thresh = gr.Slider(label="TeaCache rel_l1_thresh", minimum=0.01, maximum=1.0, step=0.01, value=0.15, visible=False, info='Порог L1-расхождения')
+                                f1_teacache_num_steps = gr.Slider(label="TeaCache num_steps", minimum=1, maximum=50, step=1, value=25, visible=False, info='Number of intermediate steps for the cache')
+                                f1_teacache_rel_l1_thresh = gr.Slider(label="TeaCache rel_l1_thresh", minimum=0.01, maximum=1.0, step=0.01, value=0.15, visible=False, info='Relative L1 divergence threshold')
                                 f1_use_teacache.change(lambda enabled: (gr.update(visible=enabled), gr.update(visible=enabled)), inputs=f1_use_teacache, outputs=[f1_teacache_num_steps, f1_teacache_rel_l1_thresh])
                                 f1_n_prompt = gr.Textbox(label="Negative Prompt", value="", visible=True)
 

--- a/studio.py
+++ b/studio.py
@@ -281,6 +281,8 @@ def worker(
     rs, 
     gpu_memory_preservation, 
     use_teacache, 
+    teacache_num_steps, 
+    teacache_rel_l1_thresh, 
     mp4_crf, 
     save_metadata, 
     blend_sections, 
@@ -747,7 +749,7 @@ def worker(
                     move_lora_adapters_to_device(current_transformer, gpu)
 
             if use_teacache:
-                current_transformer.initialize_teacache(enable_teacache=True, num_steps=steps)
+                current_transformer.initialize_teacache(enable_teacache=True, num_steps=teacache_num_steps, rel_l1_thresh=teacache_rel_l1_thresh)
             else:
                 current_transformer.initialize_teacache(enable_teacache=False)
 
@@ -920,6 +922,8 @@ def process(
         rs, 
         gpu_memory_preservation, 
         use_teacache, 
+        teacache_num_steps, 
+        teacache_rel_l1_thresh, 
         mp4_crf, 
         save_metadata,
         blend_sections, 
@@ -977,6 +981,8 @@ def process(
         'blend_sections': blend_sections,
         'gpu_memory_preservation': gpu_memory_preservation,
         'use_teacache': use_teacache,
+        'teacache_num_steps': teacache_num_steps,
+        'teacache_rel_l1_thresh': teacache_rel_l1_thresh,
         'mp4_crf': mp4_crf,
         'save_metadata': save_metadata,
         'selected_loras': selected_loras,


### PR DESCRIPTION
- Introduce two new TeaCache sliders:
  - **num_steps**: number of intermediate frames to keep in cache
  - **rel_l1_thresh**: relative L1 divergence threshold for cache refresh
- Update `studio.py` and `interface.py`

![Screenshot 2025-05-13 074207](https://github.com/user-attachments/assets/703f438e-2d0f-4b03-9868-63700b02cc3d)