### PR TITLE
Add offline arg to transformer load

### DIFF
--- a/modules/generators/f1_generator.py
+++ b/modules/generators/f1_generator.py
@@ -24,28 +24,44 @@ class F1ModelGenerator(BaseModelGenerator):
         """
         return self.model_name
 
+    def _get_offline_load_path(self) -> str:
+        """
+        Attempts to find a specific local snapshot path for offline loading.
+        If a specific snapshot is found, its path is returned.
+        Otherwise, returns the default self.model_path as a fallback
+        This method is only intended to be called when self.offline is True.
+        """
+        snapshot_hash = self._get_snapshot_hash_from_refs(self.model_repo_id_for_cache)
+        hf_home = os.environ.get('HF_HOME')
+
+        if snapshot_hash and hf_home:
+            specific_snapshot_path = os.path.join(
+                hf_home, 'hub', self.model_repo_id_for_cache, 'snapshots', snapshot_hash
+            )
+            if os.path.isdir(specific_snapshot_path):
+                print(f"Offline mode: Using specific snapshot path: {specific_snapshot_path}")
+                return specific_snapshot_path
+            else:
+                # _get_snapshot_hash_from_refs prints warnings if hash/refs file is missing
+                print(f"Offline mode: Specific snapshot directory not found at '{specific_snapshot_path}'.")
+        else:
+            # _get_snapshot_hash_from_refs prints warnings if hf_home or hash is missing
+            print(f"Offline mode: Could not determine specific snapshot details.")
+        
+        print(f"Offline mode: Falling back to default model path for {self.model_name}: {self.model_path}")
+        return self.model_path
+        
     def load_model(self):
         """
         Load the F1 transformer model.
-        If offline mode is True AND a specific local snapshot can be identified, loads from there.
-        Otherwise, uses the standard self.model_path.
         """
-        print(f"Loading {self.model_name} Transformer...") 
+        print(f"Loading {self.model_name} Transformer...")
         
         path_to_load = self.model_path # Initialize with the default path
 
         if self.offline:
-            snapshot_hash = self._get_snapshot_hash_from_refs(self.model_repo_id_for_cache)
-            hf_home = os.environ.get('HF_HOME')
+            path_to_load = self._get_offline_load_path()
 
-            if snapshot_hash and hf_home:
-                specific_snapshot_path = os.path.join(hf_home, 'hub', self.model_repo_id_for_cache, 'snapshots', snapshot_hash)
-                if os.path.isdir(specific_snapshot_path):
-                    print(f"Offline mode: Using specific snapshot path for {self.model_name}.")
-                    path_to_load = specific_snapshot_path 
-            # If snapshot_hash, hf_home, or specific_snapshot_path dir check fails, path_to_load remains self.model_path.
-            # fallback to downloading transformer if internet connection allows. 
-        
         # Create the transformer model
         self.transformer = HunyuanVideoTransformer3DModelPacked.from_pretrained(
             path_to_load, 
@@ -61,7 +77,7 @@ class F1ModelGenerator(BaseModelGenerator):
         if not self.high_vram:
             DynamicSwapInstaller.install_model(self.transformer, device=self.gpu)
         
-        print(f"{self.model_name} Transformer Loaded.")
+        print(f"{self.model_name} Transformer Loaded from {path_to_load}.")
         return self.transformer
 
     def prepare_history_latents(self, height, width):

--- a/modules/generators/f1_generator.py
+++ b/modules/generators/f1_generator.py
@@ -24,43 +24,17 @@ class F1ModelGenerator(BaseModelGenerator):
         """
         return self.model_name
 
-    def _get_offline_load_path(self) -> str:
-        """
-        Attempts to find a specific local snapshot path for offline loading.
-        If a specific snapshot is found, its path is returned.
-        Otherwise, returns the default self.model_path as a fallback
-        This method is only intended to be called when self.offline is True.
-        """
-        snapshot_hash = self._get_snapshot_hash_from_refs(self.model_repo_id_for_cache)
-        hf_home = os.environ.get('HF_HOME')
-
-        if snapshot_hash and hf_home:
-            specific_snapshot_path = os.path.join(
-                hf_home, 'hub', self.model_repo_id_for_cache, 'snapshots', snapshot_hash
-            )
-            if os.path.isdir(specific_snapshot_path):
-                print(f"Offline mode: Using specific snapshot path: {specific_snapshot_path}")
-                return specific_snapshot_path
-            else:
-                # _get_snapshot_hash_from_refs prints warnings if hash/refs file is missing
-                print(f"Offline mode: Specific snapshot directory not found at '{specific_snapshot_path}'.")
-        else:
-            # _get_snapshot_hash_from_refs prints warnings if hf_home or hash is missing
-            print(f"Offline mode: Could not determine specific snapshot details.")
-        
-        print(f"Offline mode: Falling back to default model path for {self.model_name}: {self.model_path}")
-        return self.model_path
-        
     def load_model(self):
         """
         Load the F1 transformer model.
+        If offline mode is True, attempts to load from a local snapshot.
         """
         print(f"Loading {self.model_name} Transformer...")
         
         path_to_load = self.model_path # Initialize with the default path
 
         if self.offline:
-            path_to_load = self._get_offline_load_path()
+            path_to_load = self._get_offline_load_path() # Calls the method in BaseModelGenerator
 
         # Create the transformer model
         self.transformer = HunyuanVideoTransformer3DModelPacked.from_pretrained(

--- a/modules/generators/f1_generator.py
+++ b/modules/generators/f1_generator.py
@@ -1,4 +1,5 @@
 import torch
+import os # for offline loading path
 from diffusers_helper.models.hunyuan_video_packed import HunyuanVideoTransformer3DModelPacked
 from diffusers_helper.memory import DynamicSwapInstaller
 from .base_generator import BaseModelGenerator
@@ -15,22 +16,39 @@ class F1ModelGenerator(BaseModelGenerator):
         super().__init__(**kwargs)
         self.model_name = "F1"
         self.model_path = 'lllyasviel/FramePack_F1_I2V_HY_20250503'
+        self.model_repo_id_for_cache = "models--lllyasviel--FramePack_F1_I2V_HY_20250503" 
     
     def get_model_name(self):
         """
         Get the name of the model.
         """
         return self.model_name
-    
+
     def load_model(self):
         """
         Load the F1 transformer model.
+        If offline mode is True AND a specific local snapshot can be identified, loads from there.
+        Otherwise, uses the standard self.model_path.
         """
-        print(f"Loading {self.model_name} Transformer...")
+        print(f"Loading {self.model_name} Transformer...") 
+        
+        path_to_load = self.model_path # Initialize with the default path
+
+        if self.offline:
+            snapshot_hash = self._get_snapshot_hash_from_refs(self.model_repo_id_for_cache)
+            hf_home = os.environ.get('HF_HOME')
+
+            if snapshot_hash and hf_home:
+                specific_snapshot_path = os.path.join(hf_home, 'hub', self.model_repo_id_for_cache, 'snapshots', snapshot_hash)
+                if os.path.isdir(specific_snapshot_path):
+                    print(f"Offline mode: Using specific snapshot path for {self.model_name}.")
+                    path_to_load = specific_snapshot_path 
+            # If snapshot_hash, hf_home, or specific_snapshot_path dir check fails, path_to_load remains self.model_path.
+            # fallback to downloading transformer if internet connection allows. 
         
         # Create the transformer model
         self.transformer = HunyuanVideoTransformer3DModelPacked.from_pretrained(
-            self.model_path, 
+            path_to_load, 
             torch_dtype=torch.bfloat16
         ).cpu()
         
@@ -45,7 +63,7 @@ class F1ModelGenerator(BaseModelGenerator):
         
         print(f"{self.model_name} Transformer Loaded.")
         return self.transformer
-    
+
     def prepare_history_latents(self, height, width):
         """
         Prepare the history latents tensor for the F1 model.

--- a/modules/generators/original_generator.py
+++ b/modules/generators/original_generator.py
@@ -27,24 +27,14 @@ class OriginalModelGenerator(BaseModelGenerator):
     def load_model(self):
         """
         Load the Original transformer model.
-        If offline mode is True AND a specific local snapshot can be identified, loads from there.
-        Otherwise, uses the standard self.model_path.
+        If offline mode is True, attempts to load from a local snapshot.
         """
         print(f"Loading {self.model_name} Transformer...") 
         
-        path_to_load = self.model_path # Initialize with the default/online path
+        path_to_load = self.model_path # Initialize with the default path
 
         if self.offline:
-            snapshot_hash = self._get_snapshot_hash_from_refs(self.model_repo_id_for_cache) 
-            hf_home = os.environ.get('HF_HOME')
-
-            if snapshot_hash and hf_home:
-                specific_snapshot_path = os.path.join(hf_home, 'hub', self.model_repo_id_for_cache, 'snapshots', snapshot_hash)
-                if os.path.isdir(specific_snapshot_path):
-                    print(f"Offline mode: Using specific snapshot path for {self.model_name}.") 
-                    path_to_load = specific_snapshot_path
-            # If snapshot_hash, hf_home, or specific_snapshot_path dir check fails, path_to_load remains self.model_path.
-            # # fallback to downloading transformer if internet connection allows.  
+            path_to_load = self._get_offline_load_path() # Calls the method in BaseModelGenerator
         
         # Create the transformer model
         self.transformer = HunyuanVideoTransformer3DModelPacked.from_pretrained(
@@ -61,7 +51,7 @@ class OriginalModelGenerator(BaseModelGenerator):
         if not self.high_vram:
             DynamicSwapInstaller.install_model(self.transformer, device=self.gpu)
         
-        print(f"{self.model_name} Transformer Loaded.")
+        print(f"{self.model_name} Transformer Loaded from {path_to_load}.")
         return self.transformer
     
     def prepare_history_latents(self, height, width):

--- a/studio.py
+++ b/studio.py
@@ -79,9 +79,17 @@ parser.add_argument("--server", type=str, default='0.0.0.0')
 parser.add_argument("--port", type=int, required=False)
 parser.add_argument("--inbrowser", action='store_true')
 parser.add_argument("--lora", type=str, default=None, help="Lora path (comma separated for multiple)")
+parser.add_argument("--offline", action='store_true', help="Run in offline mode")
 args = parser.parse_args()
 
 print(args)
+
+if args.offline:
+    print("Offline mode enabled.")
+    os.environ['HF_HUB_OFFLINE'] = '1'
+else:
+    if 'HF_HUB_OFFLINE' in os.environ:
+        del os.environ['HF_HUB_OFFLINE']
 
 free_mem_gb = get_cuda_free_memory_gb(gpu)
 high_vram = free_mem_gb > 60
@@ -278,7 +286,7 @@ def worker(
     resolutionH=640,
     lora_loaded_names=[]
 ):
-    global high_vram, current_generator
+    global high_vram, current_generator, args
     
     # Ensure any existing LoRAs are unloaded from the current generator
     if current_generator is not None:
@@ -328,6 +336,7 @@ def worker(
             feature_extractor=feature_extractor,
             high_vram=high_vram,
             prompt_embedding_cache=prompt_embedding_cache,
+            offline=args.offline,
             settings=settings
         )
         


### PR DESCRIPTION
Refactors the offline transformer loading (from #95) into the new model loading system.

- Offline path logic is now centralized in BaseModelGenerator.
- Tried to reduce impact in the generator files.

Required due to the transformer loading not respecting HF offline flags (HF_HUB_OFFLINE, local_files_only, TRANSFORMERS_OFFLINE) specifically.  The other model loads work correctly without this additional fuss. 

I assume this is a bug in `huggingface_hub/_snapshot_download.py` but working around it in this instance seems appropriate. 

--offline arg will be integrated into Pinokio launcher via https://github.com/ai-anchorite/FP-Studio/commit/1fde6b64f58a50c13ef17dd138ddd90214f72b89