### PR TITLE
enable reusing of downloaded models

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+PATH_MODEL_HunyuanVideo = ../models/HunyuanVideo
+PATH_MODEL_flux_redux_bfl = ../models/flux_redux_bfl
+PATH_MODEL_FramePack_F1_I2V_HY_20250503 = ../models/FramePack_F1_I2V_HY_20250503
+PATH_MODEL_FramePackI2V_HY = ../models/FramePackI2V_HY
+HF_HOME = ../models/hf_home

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Install via the Pinokio community script "FP-Studio" or:
    pip install -r requirements.txt
    ```
 
+3. If you are migrating from other projects or have your models already downloaded, you can put the paths in the provided `.env` file. Just open with any text editor and change your existing directories. If they are not valid the script will autodownload the models.
+
 ## Usage
 
 Run the studio interface:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ einops
 opencv-contrib-python
 safetensors
 peft
+python-dotenv


### PR DESCRIPTION
This PR enables the definition of paths to existing models or github cache directories. This way when users download the models on their own or are migrating from other projects, they dont have to re-download 90GB of models. The PR is done in a transparent way: if the env file contains directories that do not exist, then the current settings are used. This way after pulling this change users will still have their installations intact and working. Nothing changes for them. But new users can set their old directory in the env (without touching code) and immediately reuse their existing models. See #119