### PR TITLE
Integrate pftq video extension endframe

### DIFF
--- a/modules/interface.py
+++ b/modules/interface.py
@@ -1491,7 +1491,7 @@ def create_interface(
             actual_end_frame_image_for_backend = None
             actual_end_frame_strength_for_backend = 1.0  # Default strength
 
-            if model_type == "Original with Endframe" or model_type == "F1 with Endframe":
+            if model_type == "Original with Endframe" or model_type == "F1 with Endframe" or model_type == "Video":
                 actual_end_frame_image_for_backend = end_frame_image_original # Use the unpacked value
                 actual_end_frame_strength_for_backend = end_frame_strength_original # Use the unpacked value
 


### PR DESCRIPTION
In order to pass the endframe and weight from gradio, I HACKED a line just to treat Video as if it were an endframe model. So to make this work until gradio is set up, you have to:
- Go to the "Original with Endframe" model
- Add an endframe on that page
- Switch to the Video model, set it up with a video to extend, prompt, etc.
- Add to queue (from the Video model)

I spent way too long trying to figure out gradio, then decided to focus on the endframe functionality and leave the GUI part. Maybe I can hand that off?

It works like an absolute dream!

You'll see a couple notes in the code about my absolute lack of python experience. You'll probably laugh, that's ok. I could figure it out, but it's already really late, and I want to get this in to integrate before the codebase moves forward. No merges. Please make my python better. ;-)