### PR TITLE
Fix/num_cleaned_frames

### DIFF
--- a/modules/generators/video_generator.py
+++ b/modules/generators/video_generator.py
@@ -56,6 +56,10 @@ class VideoModelGenerator(VideoBaseModelGenerator):
         Returns:
             A tuple of (clean_latent_indices, latent_indices, clean_latent_2x_indices, clean_latent_4x_indices, clean_latents, clean_latents_2x, clean_latents_4x)
         """
+        # Get num_cleaned_frames from job_params if available, otherwise use default value of 5
+        num_clean_frames = num_cleaned_frames if num_cleaned_frames is not None else 5
+
+
         # HACK SOME STUFF IN THAT SHOULD NOT BE HERE
         # Placeholders for end frame processing
         # Colin, I'm only leaving them for the moment in case you want separate models for


### PR DESCRIPTION
When you wove num_cleaned_frames to the generators, video_generator.py missed one line that you had in video_f1_generator.py, leaving num_clean_frames (the original variable) undefined.

Could rename everywhere to num_clean_frames, but maybe we'll choose a better name when we refactor post-release anyway. ;-)

This is enough to get VideoModelGenerator working again.