### PR TITLE
Suppress single lora bug

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,2 +1,4 @@
 # modules/__init__.py
 
+# Workaround for the single lora bug. Must not be an empty string.
+DUMMY_LORA_NAME = " "

--- a/studio.py
+++ b/studio.py
@@ -49,6 +49,7 @@ from modules.video_queue import VideoJobQueue, JobStatus
 from modules.prompt_handler import parse_timestamped_prompt
 from modules.interface import create_interface, format_queue_status
 from modules.settings import Settings
+from modules import DUMMY_LORA_NAME # Import the constant
 from modules.pipelines.metadata_utils import create_metadata
 from modules.pipelines.worker import worker
 
@@ -210,6 +211,9 @@ if os.path.isdir(lora_folder_from_settings):
                     lora_name = str(PurePath(lora_relative_path).with_suffix(''))
                     lora_names.append(lora_name)
         print(f"Found LoRAs: {lora_names}")
+        # Temp solution for only 1 lora
+        if len(lora_names) == 1:
+            lora_names.append(DUMMY_LORA_NAME)
     except Exception as e:
         print(f"Error scanning LoRA directory '{lora_folder_from_settings}': {e}")
 else:


### PR DESCRIPTION
@colinurbs this is instead of Xipomus PR: Workarround Single Lora bug #198

Workaround for the Single Lora bug that seems to be a subtle gradio problem.

It carries the ideas from Xipomus further. I pass the dummy lora name as he did when there's exactly one lora available. Then in interface, I suppress the name and slider from being displayed if the user does attempt to select it. Finally the worker does a check and filters out the dummy lora if it was somehow supplied.

Because there's now not a danger of the user selecting the dummy lora, it doesn't need the scary warning text, "dummy lora - DO NOT USE - will disappear with multiple loras". It just has to be any non-empty string, so I made it " " (a space).  Looks very natural in the UI now. Users won't even realize we're working around this bug.