### PR TITLE
Fix for Video error and change video latent

### DIFF
--- a/modules/generators/video_base_generator.py
+++ b/modules/generators/video_base_generator.py
@@ -111,7 +111,7 @@ class VideoBaseModelGenerator(BaseModelGenerator):
 
         max_latents_used_for_context = 27
         if self.get_model_name() == "Video":
-            max_latents_used_for_context = 19
+            max_latents_used_for_context = 27  # Weird results on 19
         elif self.get_model_name() == "Video F1":
             max_latents_used_for_context = 27  # Enough for even Video F1 with cleaned_frames input of 10
         else:

--- a/modules/generators/video_base_generator.py
+++ b/modules/generators/video_base_generator.py
@@ -110,9 +110,9 @@ class VideoBaseModelGenerator(BaseModelGenerator):
         """
 
         max_latents_used_for_context = 27
-        if self.get_model_name == "Video":
+        if self.get_model_name() == "Video":
             max_latents_used_for_context = 19
-        elif self.get_model_name == "Video F1":
+        elif self.get_model_name() == "Video F1":
             max_latents_used_for_context = 27  # Enough for even Video F1 with cleaned_frames input of 10
         else:
             print("======================================================")


### PR DESCRIPTION
Fix for Video error in console on rendering:
Initializing VideoReader...
Video loaded: 217 frames, FPS: 30.0
Reading video frames...
======================================================
        Warning: Unsupported video extension model type: Video.
        Using default max latents {max_latents_used_for_context} for context.
        Please report to the developers if you see this message:

and because Video and Video Endframe suddenly gave very different results, i put the latent on the error 27 on the normal video too instead of the 19.

Renders are now the same as with the errors, but the errors are gone