### PR TITLE
feat: Add start-up temp file clean-up 

### DIFF
--- a/modules/interface.py
+++ b/modules/interface.py
@@ -843,12 +843,6 @@ def create_interface(
                             value=settings.get("clean_up_videos", True),
                             info="If checked, only the final video will be kept after generation."
                         )
-                        cleanup_temp_folder = gr.Checkbox(
-                            label="Clean up temp folder after generation",
-                            visible=False,
-                            value=settings.get("cleanup_temp_folder", True),
-                            info="If checked, temporary files will be cleaned up after each generation."
-                        )
                         auto_cleanup_on_startup = gr.Checkbox(
                             label="Automatically clean up temp folders on startup",
                             value=settings.get("auto_cleanup_on_startup", False),
@@ -940,7 +934,7 @@ def create_interface(
                         status = gr.HTML("")
                         cleanup_output = gr.Textbox(label="Cleanup Status", interactive=False)
 
-                        def save_settings(save_metadata, gpu_memory_preservation, mp4_crf, clean_up_videos, cleanup_temp_folder, auto_cleanup_on_startup_val, override_system_prompt_value, system_prompt_template_value, output_dir, metadata_dir, lora_dir, gradio_temp_dir, auto_save, selected_theme, startup_model_type_val, startup_preset_name_val):
+                        def save_settings(save_metadata, gpu_memory_preservation, mp4_crf, clean_up_videos, auto_cleanup_on_startup_val, override_system_prompt_value, system_prompt_template_value, output_dir, metadata_dir, lora_dir, gradio_temp_dir, auto_save, selected_theme, startup_model_type_val, startup_preset_name_val):
                             """Handles the manual 'Save Settings' button click."""
                             # This function is for the manual save button.
                             # It collects all current UI values and saves them.
@@ -958,7 +952,6 @@ def create_interface(
                                     gpu_memory_preservation=gpu_memory_preservation,
                                     mp4_crf=mp4_crf,
                                     clean_up_videos=clean_up_videos,
-                                    cleanup_temp_folder=cleanup_temp_folder,
                                     auto_cleanup_on_startup=auto_cleanup_on_startup_val, # ADDED
                                     override_system_prompt=override_system_prompt_value,
                                     system_prompt_template=processed_template,
@@ -1003,9 +996,10 @@ def create_interface(
                                 else:
                                     return f"<p style='color:gray;'>'{setting_name_for_ui}' setting changed (auto-save is off, click 'Save Settings').</p>"
 
+                        # REMOVE `cleanup_temp_folder` from the `inputs` list
                         save_btn.click(
                             fn=save_settings,
-                            inputs=[save_metadata, gpu_memory_preservation, mp4_crf, clean_up_videos, cleanup_temp_folder, auto_cleanup_on_startup, override_system_prompt, system_prompt_template, output_dir, metadata_dir, lora_dir, gradio_temp_dir, auto_save, theme_dropdown, startup_model_type_dropdown, startup_preset_name_dropdown],
+                            inputs=[save_metadata, gpu_memory_preservation, mp4_crf, clean_up_videos, auto_cleanup_on_startup, override_system_prompt, system_prompt_template, output_dir, metadata_dir, lora_dir, gradio_temp_dir, auto_save, theme_dropdown, startup_model_type_dropdown, startup_preset_name_dropdown],
                             outputs=[status]
                         )
 
@@ -1037,9 +1031,6 @@ def create_interface(
                         mp4_crf.change(lambda v: handle_individual_setting_change("mp4_crf", v, "MP4 Compression"), inputs=[mp4_crf], outputs=[status])
                         clean_up_videos.change(lambda v: handle_individual_setting_change("clean_up_videos", v, "Clean Up Videos"), inputs=[clean_up_videos], outputs=[status])
 
-                        # This setting is not visible in the UI, but still handle it in case it's re-added to the UI
-                        cleanup_temp_folder.change(lambda v: handle_individual_setting_change("cleanup_temp_folder", v, "Cleanup Temp Folder"), inputs=[cleanup_temp_folder], outputs=[status])
-                        
                         # NEW: auto-cleanup temp files on startup checkbox
                         auto_cleanup_on_startup.change(lambda v: handle_individual_setting_change("auto_cleanup_on_startup", v, "Auto Cleanup on Startup"), inputs=[auto_cleanup_on_startup], outputs=[status])
 

--- a/modules/pipelines/worker.py
+++ b/modules/pipelines/worker.py
@@ -176,7 +176,6 @@ def worker(
             "gpu_memory_preservation": settings.get("gpu_memory_preservation", 6),
             "mp4_crf": settings.get("mp4_crf", 16),
             "clean_up_videos": settings.get("clean_up_videos", True),
-            "cleanup_temp_folder": settings.get("cleanup_temp_folder", True),
             "gradio_temp_dir": settings.get("gradio_temp_dir", "./gradio_temp"),
             "high_vram": high_vram
         }
@@ -907,30 +906,6 @@ def worker(
                             print(f"Failed to delete {full_path}: {e}")
             except Exception as e:
                 print(f"Error during video cleanup: {e}")
-        
-        # Clean up temp folder if enabled
-        if settings.get("cleanup_temp_folder"):
-            try:
-                temp_dir = settings.get("gradio_temp_dir")
-                if temp_dir and os.path.exists(temp_dir): # Check if temp_dir is not None before os.path.exists
-                    print(f"Cleaning up temp folder: {temp_dir}")
-                    items = os.listdir(temp_dir)
-                    removed_count = 0
-                    for item in items:
-                        item_path = os.path.join(temp_dir, item)
-                        try:
-                            if os.path.isfile(item_path) or os.path.islink(item_path):
-                                os.remove(item_path)
-                                removed_count += 1
-                            elif os.path.isdir(item_path):
-                                import shutil # Import shutil here as it's only used in this block
-                                shutil.rmtree(item_path)
-                                removed_count += 1
-                        except Exception as e:
-                            print(f"Error removing {item_path}: {e}")
-                    print(f"Cleaned up {removed_count} temporary files/folders.")
-            except Exception as e:
-                print(f"Error during temp folder cleanup: {e}")
 
         # Check if the user wants to combine the source video with the generated video
         # This is done after the video cleanup routine to ensure the combined video is not deleted

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -24,8 +24,8 @@ class Settings:
             "gradio_theme": "default",
             "mp4_crf": 16,
             "clean_up_videos": True,
-            "cleanup_temp_folder": False,
             "override_system_prompt": False,
+            "auto_cleanup_on_startup": False, # ADDED: New setting for startup cleanup
             "system_prompt_template": "{\"template\": \"<|start_header_id|>system<|end_header_id|>\\n\\nDescribe the video by detailing the following aspects: 1. The main content and theme of the video.2. The color, shape, size, texture, quantity, text, and spatial relationships of the objects.3. Actions, events, behaviors temporal relationships, physical movement changes of the objects.4. background environment, light, style and atmosphere.5. camera angles, movements, and transitions used in the video:<|eot_id|><|start_header_id|>user<|end_header_id|>\\n\\n{}<|eot_id|>\", \"crop_start\": 95}",
             "startup_model_type": "None",
             "startup_preset_name": None

--- a/studio.py
+++ b/studio.py
@@ -3,7 +3,7 @@ from diffusers_helper.hf_login import login
 import json
 import os
 import shutil
-from pathlib import PurePath
+from pathlib import PurePath, Path
 import time
 import argparse
 import traceback
@@ -199,6 +199,19 @@ os.makedirs(outputs_folder, exist_ok=True)
 # Initialize settings
 settings = Settings()
 
+# NEW: auto-cleanup on start-up option in Settings
+if settings.get("auto_cleanup_on_startup", False):
+    print("--- Running Automatic Startup Cleanup ---")
+    
+    # Import the processor instance
+    from modules.toolbox_app import tb_processor
+    
+    # Call the single cleanup function and print its summary.
+    cleanup_summary = tb_processor.tb_clear_temporary_files()
+    print(f"{cleanup_summary}") # This cleaner print handles the multiline string well
+    
+    print("--- Startup Cleanup Complete ---")
+        
 # --- Populate LoRA names AFTER settings are loaded ---
 lora_folder_from_settings: str = settings.get("lora_dir", default_lora_folder) # Use setting, fallback to default
 print(f"Scanning for LoRAs in: {lora_folder_from_settings}")


### PR DESCRIPTION
Adds a checkbox to Settings to perform temp folders clean-up on start.

All clean-up logic has been centralized into `VideoProcessor.tb_clear_temporary_files()` for consistency. The method now cleans both the main Gradio temp directory and the post-processing temp directory.

Did a clean up of the script initialization and import ordering at the top of toolbox_app.py

Also tidied away the `cleanup_temp_folder` (after generation) settings/code