### PR TITLE
Improve install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,35 @@ Install via the Pinokio community script "FP-Studio" or:
    cd FramePack-Studio
    ```
 
-2. Install PyTorch:
+2. Create a Python virtual environment (venv):
 
-   Go to the [PyTorch Getting Started](https://pytorch.org/get-started/locally/) page and install PyTorch according to your system setup.
-   For example, if using CUDA 12.6 on Windows:
+   For Linux:
+
    ```bash
-   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+   python -m venv venv/
+   source venv/bin/activate
+   ```
+
+   For Windows:
+
+   ```
+   python -m venv venv/
+   ./venv/Scripts/activate.bat
    ```
 
 3. Install additional dependencies:
+
    ```bash
    pip install -r requirements.txt
+   ```
+
+4. Install PyTorch:
+
+   Go to the [PyTorch Getting Started](https://pytorch.org/get-started/locally/) page and install PyTorch according to your system setup.
+   For example, if using CUDA 12.6 on Windows:
+
+   ```bash
+   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
    ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <h1 align="center">FramePack Studio</h1>
 
-
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/MtuM7gFJ3V)[![Patreon](https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/ColinU)
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/colinurbs/FramePack-Studio)
 
-FramePack Studio is an AI video generation application based on FramePack that strives to provide everything you need to create high quality video projects. 
+FramePack Studio is an AI video generation application based on FramePack that strives to provide everything you need to create high quality video projects.
 
 ## Current Features
 
@@ -19,7 +18,6 @@ FramePack Studio is an AI video generation application based on FramePack that s
 - **Metadata Saving/Import**: Prompt and seed are encoded into the output PNG, all other generation metadata is saved in a JSON file
 - **I2V and T2V**: Works with or without an input image to allow for more flexibility when working with standard LoRAs
 - **Latent Image Options**: When using T2V you can generate based on a black, white, green screen or pure noise image
-
 
 ## Fresh Installation
 
@@ -35,6 +33,7 @@ FramePack Studio is an AI video generation application based on FramePack that s
 Install via the Pinokio community script "FP-Studio" or:
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/colinurbs/FramePack-Studio.git
    cd FramePack-Studio
@@ -80,6 +79,7 @@ python studio.py
 ```
 
 Additional command line options:
+
 - `--share`: Create a public Gradio link to share your interface
 - `--server`: Specify the server address (default: 0.0.0.0)
 - `--port`: Specify a custom port
@@ -105,13 +105,12 @@ You can create videos with changing prompts over time using the following syntax
 Each timestamp defines when that prompt should start influencing the generation. The system will (hopefully) smoothly transition between prompts for a cohesive video.
 
 ## Credits
+
 Many thanks to [Lvmin Zhang](https://github.com/lllyasviel) for the absolutely amazing work on the original [FramePack](https://github.com/lllyasviel/FramePack) code!
 
 Thanks to [Rickard Edén](https://github.com/neph1) for the LoRA code and their general contributions to this growing FramePack scene!
 
 Thanks to everyone who has joined the Discord, reported a bug, sumbitted a PR or helped with testing!
-
-
 
     @article{zhang2025framepack,
         title={Packing Input Frame Contexts in Next-Frame Prediction Models for Video Generation},


### PR DESCRIPTION
The install docs omit the necessary step of setting up a Python venv. They also put the PyTorch install first, which could cause problems because installing from requirements.txt afterward could uninstall the CUDA torch versions accidentally.