### PR TITLE
Build Docker images for CUDA 12.4/6/8 and include patch version in specifier

### DIFF
--- a/.github/actions/docker-publish-action/action.yml
+++ b/.github/actions/docker-publish-action/action.yml
@@ -34,14 +34,26 @@ runs:
       uses: docker/metadata-action@v5
       with:
         images: ${{ inputs.image_name }}
+    - name: Trim Commit SHA
+      uses: 2428392/gh-truncate-string-action@v1
+      id: trimCommitSha
+      with:
+        stringToTruncate: "${{ inputs.commit_sha }}"
+        maxLength: 8
+    - name: Trim CUDA version
+      uses: 2428392/gh-truncate-string-action@v1
+      id: trimCudaVersion
+      with:
+        stringToTruncate: "${{ inputs.cuda_version }}"
+        maxLength: 4
     - name: Build and push
       uses: docker/build-push-action@v5
       with:
         push: true
         file: Dockerfile
         tags: |
-          ${{ inputs.image_name }}:cuda${{ inputs.cuda_version }}-latest-${{ inputs.branch }}
-          ${{ inputs.image_name }}:cuda${{ inputs.cuda_version }}-${{ inputs.commit_sha }}
+          ${{ inputs.image_name }}:cuda${{ steps.trimCudaVersion.outputs.string }}-latest${{ inputs.branch == "main" && '' || join('-', inputs.branch) }}
+          ${{ inputs.image_name }}:cuda${{ steps.trimCudaVersion.outputs.string }}-${{ steps.trimCommitSha.outputs.string }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           CUDA_VERSION=${{ inputs.cuda_version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        cuda-version: ["12.9", "12.8", "12.4"]
+        cuda-version: ["12.4", "12.8"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,5 +30,5 @@ jobs:
           commit_sha: ${{ github.sha }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image_name: colinurbs439/fp-studio
+          image_name: colinurbs/fp-studio
           cuda_version: ${{ matrix.cuda-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        cuda-version: ["12.4", "12.8"]
+        cuda-version: ["12.4.1", "12.6.3", "12.8.1"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG CUDA_VERSION=12.8
+ARG CUDA_VERSION=12.4.1
 
-FROM nvidia/cuda:${CUDA_VERSION}.0-runtime-ubuntu22.04
+FROM nvidia/cuda:${CUDA_VERSION}.0-runtime-ubuntu24.04
 
 ARG CUDA_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CUDA_VERSION=12.4
+ARG CUDA_VERSION=12.8
 
 FROM nvidia/cuda:${CUDA_VERSION}.0-runtime-ubuntu22.04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG CUDA_VERSION=12.4.1
 
-FROM nvidia/cuda:${CUDA_VERSION}.0-runtime-ubuntu24.04
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu24.04
 
 ARG CUDA_VERSION
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ services:
   studio:
     build:
       context: .
+      # modify this if you are building the image locally and need a different CUDA version
       args:
         - CUDA_VERSION=12.4.1
+    # modify the tag here if you need a different CUDA version or branch
     image: colinurbs/fp-studio:cuda12.4.1-latest-develop
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   studio:
     build:
-      context: .
       # modify this if you are building the image locally and need a different CUDA version
       args:
         - CUDA_VERSION=12.4.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         - CUDA_VERSION=12.4.1
     # modify the tag here if you need a different CUDA version or branch
-    image: colinurbs/fp-studio:cuda12.4.1-latest-develop
+    image: colinurbs/fp-studio:cuda12.4-latest-develop
     restart: unless-stopped
     ports:
       - "7860:7860"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
   studio:
-    build: .
-    image: colinurbs/fp-studio:cuda12.8-latest-develop
+    build:
+      context: .
+      args:
+        - CUDA_VERSION=12.4.1
+    image: colinurbs/fp-studio:cuda12.4.1-latest-develop
     restart: unless-stopped
     ports:
       - "7860:7860"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   studio:
     build: .
-    image: colinurbs/fp-studio:cuda12.9-latest-develop
+    image: colinurbs/fp-studio:cuda12.8-latest-develop
     restart: unless-stopped
     ports:
       - "7860:7860"


### PR DESCRIPTION
Fixes failing build due to no pytorch 12.9 index URL existing yet.

Adds the patch version to the specified CUDA version - the matrix is now 12.4.1, 12.6.3, and 12.8.1. The new tag format is `cudaX.Y-latest` for main, and `cudaX.Y-latest-develop` for develop. The SHAs in the commit tags have been trimmed to 8 characters.