### PR TITLE
Try a lower number for root-reserve-mb

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 50000
+          root-reserve-mb: 32768
           swap-size-mb: 1024
           remove-dotnet: "true"
           remove-android: "true"


### PR DESCRIPTION
The last job used a root-reserve-mb that was too large. Trying a lower number that hopefully gives us enough space.