### PR TITLE
Remove more tooling, use LVM overprovisioning during GHA builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,18 @@ jobs:
       matrix:
         cuda-version: ["12.4.1", "12.6.3", "12.8.1"]
     steps:
+      - name: Clean up unneeded tooling
+        run: |
+          rm -rf /usr/share/dotnet
+          rm -rf /usr/local/lib/android
+          rm -rf /opt/ghc
+          rm -rf /usr/local/share/boost
+          rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 32768
           swap-size-mb: 1024
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
-          remove-codeql: "true"
+          overprovision-lvm: "true"
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Publish image


### PR DESCRIPTION
Hopefully gives us enough free disk space to push the images.