### PR TITLE
Try Gaussian Start Latent

### DIFF
--- a/modules/generators/f1_generator.py
+++ b/modules/generators/f1_generator.py
@@ -73,19 +73,24 @@ class F1ModelGenerator(BaseModelGenerator):
             dtype=torch.float32
         ).cpu()
     
-    def initialize_with_start_latent(self, history_latents, start_latent):
+    def initialize_with_start_latent(self, history_latents, start_latent, is_real_image_latent):
         """
         Initialize the history latents with the start latent for the F1 model.
         
         Args:
             history_latents: The history latents
             start_latent: The start latent
+            is_real_image_latent: Whether the start latent came from a real input image or is a synthetic noise
             
         Returns:
             The initialized history latents
         """
         # Add the start frame to history_latents
-        return torch.cat([history_latents, start_latent.to(history_latents)], dim=2)
+        if is_real_image_latent:
+            return torch.cat([history_latents, start_latent.to(history_latents)], dim=2)
+        # After prepare_history_latents, history_latents (initialized with zeros)
+        # already has the required 19 entries for initial clean latents
+        return history_latents
     
     def get_latent_paddings(self, total_latent_sections):
         """

--- a/modules/pipelines/worker.py
+++ b/modules/pipelines/worker.py
@@ -422,7 +422,18 @@ def worker(
                 load_model_as_complete(vae, target_device=gpu)
 
             from diffusers_helper.hunyuan import vae_encode
-            start_latent = vae_encode(input_image_pt, vae)
+            if job_params.get('latent_type') == 'Noise':
+                # Create a Gaussian latent representation directly.
+                print("***********************************************")
+                print("**   Using Gaussian noise for start_latent   **")
+                print("***********************************************")
+                noise_rnd = torch.Generator("cpu").manual_seed(seed)
+                start_latent = torch.randn(
+                    (1, 16, 1, height // 8, width // 8),
+                    generator=noise_rnd, device=noise_rnd.device
+                ).to(device=gpu, dtype=torch.float32)
+            else:
+                start_latent = vae_encode(input_image_pt, vae)
 
             # CLIP Vision
             stream_to_use.output_queue.push(('progress', (None, '', make_progress_bar_html(0, 'CLIP Vision encoding ...'))))

--- a/modules/pipelines/worker.py
+++ b/modules/pipelines/worker.py
@@ -408,42 +408,62 @@ def worker(
             input_video_frame_count = video_latents.shape[2]
         else:
             # Regular image processing
-            input_image_np = job_params['input_image']
             height = job_params['height']
             width = job_params['width']
-            
-            input_image_pt = torch.from_numpy(input_image_np).float() / 127.5 - 1
-            input_image_pt = input_image_pt.permute(2, 0, 1)[None, :, None]
 
-            # VAE encoding
-            stream_to_use.output_queue.push(('progress', (None, '', make_progress_bar_html(0, 'VAE encoding ...'))))
-
-            if not high_vram:
-                load_model_as_complete(vae, target_device=gpu)
-
-            from diffusers_helper.hunyuan import vae_encode
             if job_params.get('latent_type') == 'Noise':
-                # Create a Gaussian latent representation directly.
-                print("***********************************************")
-                print("**   Using Gaussian noise for start_latent   **")
-                print("***********************************************")
+                print("************************************************")
+                print("** Using 'Noise' latent type for T2V workflow **")
+                print("************************************************")
+
+                # Create a random latent to serve as the initial VAE context anchor.
+                # This provides a random starting point without visual bias.
                 noise_rnd = torch.Generator("cpu").manual_seed(seed)
                 start_latent = torch.randn(
                     (1, 16, 1, height // 8, width // 8),
                     generator=noise_rnd, device=noise_rnd.device
                 ).to(device=gpu, dtype=torch.float32)
+
+                # Create a neutral black image to generate a valid "null" CLIP Vision embedding.
+                # This provides the model with a valid, in-distribution unconditional image prompt.
+                # RT_BORG: Clip doesn't understand noise at all. I also tried using
+                #   image_encoder_last_hidden_state = torch.zeros((1, 257, 1152), device=gpu, dtype=studio_module.current_generator.transformer.dtype)
+                # to represent a "null" CLIP Vision embedding in the shape for the CLIP encoder,
+                # but the Video model wasn't trained to handle zeros, so using a neutral black image for CLIP.
+
+                black_image_np = np.zeros((height, width, 3), dtype=np.uint8)
+
+                if not high_vram:
+                    load_model_as_complete(image_encoder, target_device=gpu)
+
+                from diffusers_helper.clip_vision import hf_clip_vision_encode
+                image_encoder_output = hf_clip_vision_encode(black_image_np, feature_extractor, image_encoder)
+                image_encoder_last_hidden_state = image_encoder_output.last_hidden_state
+
             else:
+                input_image_np = job_params['input_image']
+                
+                input_image_pt = torch.from_numpy(input_image_np).float() / 127.5 - 1
+                input_image_pt = input_image_pt.permute(2, 0, 1)[None, :, None]
+
+                # Start image encoding with VAE
+                stream_to_use.output_queue.push(('progress', (None, '', make_progress_bar_html(0, 'VAE encoding ...'))))
+
+                if not high_vram:
+                    load_model_as_complete(vae, target_device=gpu)
+
+                from diffusers_helper.hunyuan import vae_encode
                 start_latent = vae_encode(input_image_pt, vae)
 
-            # CLIP Vision
-            stream_to_use.output_queue.push(('progress', (None, '', make_progress_bar_html(0, 'CLIP Vision encoding ...'))))
+                # CLIP Vision
+                stream_to_use.output_queue.push(('progress', (None, '', make_progress_bar_html(0, 'CLIP Vision encoding ...'))))
 
-            if not high_vram:
-                load_model_as_complete(image_encoder, target_device=gpu)
+                if not high_vram:
+                    load_model_as_complete(image_encoder, target_device=gpu)
 
-            from diffusers_helper.clip_vision import hf_clip_vision_encode
-            image_encoder_output = hf_clip_vision_encode(input_image_np, feature_extractor, image_encoder)
-            image_encoder_last_hidden_state = image_encoder_output.last_hidden_state
+                from diffusers_helper.clip_vision import hf_clip_vision_encode
+                image_encoder_output = hf_clip_vision_encode(input_image_np, feature_extractor, image_encoder)
+                image_encoder_last_hidden_state = image_encoder_output.last_hidden_state
 
         # VAE encode end_frame_image if provided
         end_frame_latent = None
@@ -525,7 +545,10 @@ def worker(
             
             # For F1 model, initialize with start latent
             if model_type == "F1":
-                history_latents = studio_module.current_generator.initialize_with_start_latent(history_latents, start_latent)
+                # RT_BORG: For the experiment, switch on 'Noise' latent type. Eventually it should probably be something like input_image is None
+                # but the synthetic input_image is used elsewhere for the queue, so I'm using 'Noise' as my switch for now.
+                is_real_image_latent = latent_type != 'Noise'
+                history_latents = studio_module.current_generator.initialize_with_start_latent(history_latents, start_latent, is_real_image_latent)
                 total_generated_latent_frames = 1  # Start with 1 for F1 model since it includes the first frame
             elif model_type == "Original" or model_type == "Original with Endframe":
                 total_generated_latent_frames = 0


### PR DESCRIPTION
@colinurbs This is to try the true gaussian noise, instead of the (broken) vae conversion of a "random image".

I didn't mess with UI or anything. Since we're passing "latent_type" through to worker, I just check if it's "Noise" at the point we convert the start image, and if so use a latent from gaussian noise instead of using the vae.

**To try it:**
Just select Latent Image Options > Noise 

Default (black) hasn't changed.

Not sure if it's better outcomes than black, since I'm getting good t2v generations with both. So someone who hasn't liked their current t2v outcomes should test and verify.

Unfortunately, changing the t2v start image gives you a different video, even with the same seed (basically the same level of difference as choosing a different seed) so it isn't a simple 1-to-1 comparison.

Note: I made a `noise_rnd = torch.Generator("cpu").manual_seed(seed)` rather than reusing the rnd we already have because that's defined lower down and I just wanted to keep this completely isolated unless we go with it. (Also, it doesn't use the existing rnd, so if it *were* to generate a similar video with the same seed, we'd see it. Sadly, it doesn't.)